### PR TITLE
Added "LICENSE.txt" and "README.txt" as recognized filenames

### DIFF
--- a/src/package.jl
+++ b/src/package.jl
@@ -22,8 +22,10 @@ function checkLicense(features, pkg_path)
   # Test for some sort of license file first
   possible_files = [joinpath(pkg_path, "LICENSE"),
                     joinpath(pkg_path, "LICENSE.md"),
+                    joinpath(pkg_path, "LICENSE.txt"),
                     joinpath(pkg_path, "README"),
-                    joinpath(pkg_path, "README.md")]
+                    joinpath(pkg_path, "README.md"),
+                    joinpath(pkg_path, "README.txt")]
   for filename in possible_files
     if isfile(filename)
       if guessLicense(features, filename)


### PR DESCRIPTION
The webstack packages (HttpCommon, Meddle, etc) have license files named "LICENSE.txt", which means they don't currently get detected by PackageEvaluator. This fixes that by adding both "LICENSE.txt" and "README.txt" as recognized file names.

This is probably not the best fix, since you might want to accept README.\* and LICENSE.*, rather than only specific endings.
