### PR TITLE
Add Synchrony => CrossDecomposition to exceptions

### DIFF
--- a/extra/genresults.jl
+++ b/extra/genresults.jl
@@ -121,7 +121,8 @@ const EXCEPTIONS = ["HTTPClient" => ["JSON"],
                     "MarketTechnicals" => ["Datetime", "FactCheck","MarketData"],
                     "DecisionTree" => ["RDatasets"],
                     "ExpressionUtils" => ["FactCheck"],
-                    "TimeSeries" => ["MarketData"]
+                    "TimeSeries" => ["MarketData"],
+                    "Synchrony" => ["CrossDecomposition"]
                     ]
 
 # exceptions_before


### PR DESCRIPTION
It also looks like `TimeSeries` appears twice in this list; not sure what should happen with that.
