### PR TITLE
Exclude PyX.jl (has Python dependency)

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -128,6 +128,7 @@ const PKGOPTS = Dict([
     ("PyLexYacc"              , :PYTHON),    # Needs PLY and attrdict
     ("PyPlot"                 , :XVFB),      # GUI
     ("PySide"                 , :PYTHON),    # Needs PySide/Qt
+    ("PyX"                    , :PYTHON),    # Needs PyX
     ("QuartzImageIO"          , :OSX),
     ("RdRand"                 , :BINARY),    # Needs latest Intel CPU
     ("REPLCompletions"        , :DEP),       # Deprecated, just throws error (???)


### PR DESCRIPTION
The PyX package has some large deps (like a LaTeX/TeX install).
There are working (passing) tests running on Travis, but i'll note that the Travis test script is complicated and takes a long time to run.