### PR TITLE
test on 0.6-dev instead of 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false
 sudo: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd())'
-    - julia -e 'Pkg.test("PackageEvaluator")'
+#script:
+#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#    - julia -e 'Pkg.clone(pwd())'
+#    - julia -e 'Pkg.test("PackageEvaluator")'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PackageEvaluator
 
 The purpose of PackageEvaluator is to attempt to test every Julia package nightly, and to provide the information required to generate the [Julia package listing](http://pkg.julialang.org/).
 
-This is currently done for both Julia 0.3 and 0.4, and the tests are run in Ubuntu 14.04 LTS ("Trusty Tahr") virtual machines managed with [Vagrant](https://www.vagrantup.com/). This allows users to debug why their tests are failing, and allows PackageEvaluator to be run almost anywhere.
+This is currently done for Julia 0.4, 0.5, and nightly, and the tests are run in Ubuntu 14.04 LTS ("Trusty Tahr") virtual machines managed with [Vagrant](https://www.vagrantup.com/). This allows users to debug why their tests are failing, and allows PackageEvaluator to be run almost anywhere.
 
 The code itself, in particular `scripts/setup.sh`, is heavily commented, so check that out for more information.
 
@@ -34,7 +34,7 @@ Possible reasons include:
 * The configuration of the virtual machine, including the operating system to use, live in the [`Vagrantfile`](https://github.com/IainNZ/PackageEvaluator.jl/blob/master/scripts/Vagrantfile).
 * When the virtual machine(s) are launched with `vagrant up`, a *provisioning script* called [`setup.sh`](https://github.com/IainNZ/PackageEvaluator.jl/blob/master/scripts/setup.sh) is run.
 * This script takes two arguments. The first is the version of Julia
-  to use (`0.3` or `0.4`)
+  to use (`0.4` or `0.5` or `0.6`)
 * The second determines the mode to operate in:
     * `setup`: set up the machine with Julia and the same
       dependencies that are used for a full PackageEvaluator run, but

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,10 @@
+julia 0.4
+JSON
+Humanize
+Mustache
+MetadataTools
+Requests
+GitHub
+JLD
+PyPlot
+Compat

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -11,14 +11,6 @@ Vagrant.configure("2") do |config|
 
   #---------------------------------------------------------------------
   # SETUP ONLY
-  config.vm.define :setup03 do |setup03|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.3", "setup"],
-      keep_color: true,
-      privileged: false
-  end
-
   config.vm.define :setup04 do |setup04|
     config.vm.provision :shell,
       path: "setup.sh",
@@ -35,16 +27,16 @@ Vagrant.configure("2") do |config|
       privileged: false
   end
 
-  #---------------------------------------------------------------------
-  # ALL PACKAGES
-  config.vm.define :all03 do |all03|
+  config.vm.define :setup06 do |setup06|
     config.vm.provision :shell,
       path: "setup.sh",
-      args: ["0.3", "all"],
+      args: ["0.6", "setup"],
       keep_color: true,
       privileged: false
   end
 
+  #---------------------------------------------------------------------
+  # ALL PACKAGES
   config.vm.define :all04 do |all04|
     config.vm.provision :shell,
       path: "setup.sh",
@@ -61,23 +53,16 @@ Vagrant.configure("2") do |config|
       privileged: false
   end
 
-  #---------------------------------------------------------------------
-  # HALF PACKAGES
-  config.vm.define :halfAL03 do |halfAL03|
+  config.vm.define :all06 do |all06|
     config.vm.provision :shell,
       path: "setup.sh",
-      args: ["0.3", "AL"],
-      keep_color: true,
-      privileged: false
-  end
-  config.vm.define :halfMZ03 do |halfMZ03|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.3", "MZ"],
+      args: ["0.6", "all"],
       keep_color: true,
       privileged: false
   end
 
+  #---------------------------------------------------------------------
+  # HALF PACKAGES
   config.vm.define :halfAL04 do |halfAL04|
     config.vm.provision :shell,
       path: "setup.sh",
@@ -104,6 +89,21 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell,
       path: "setup.sh",
       args: ["0.5", "MZ"],
+      keep_color: true,
+      privileged: false
+  end
+
+  config.vm.define :halfAL06 do |halfAL06|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.6", "AL"],
+      keep_color: true,
+      privileged: false
+  end
+  config.vm.define :halfMZ06 do |halfMZ06|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.6", "MZ"],
       keep_color: true,
       privileged: false
   end

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,4 +1,5 @@
 rm -rf ./0.3*
 rm -rf ./0.4*
 rm -rf ./0.5*
+rm -rf ./0.6*
 rm ./*.out.txt

--- a/scripts/runvagrant.sh
+++ b/scripts/runvagrant.sh
@@ -25,33 +25,33 @@ parallel_provision() {
 
 if [ "$1" == "three" ]
 then
-    vagrant up --no-provision all03
     vagrant up --no-provision all04
     vagrant up --no-provision all05
+    vagrant up --no-provision all06
 
     # Provision in parallel
     cat <<EOF | parallel_provision
-all03
 all04
 all05
+all06
 EOF
 
 else
-    vagrant up --no-provision halfAL03
-    vagrant up --no-provision halfMZ03
     vagrant up --no-provision halfAL04
     vagrant up --no-provision halfMZ04
     vagrant up --no-provision halfAL05
     vagrant up --no-provision halfMZ05
+    vagrant up --no-provision halfAL06
+    vagrant up --no-provision halfMZ06
 
     # Provision in parallel
     cat <<EOF | parallel_provision
-halfAL03
-halfMZ03
 halfAL04
 halfMZ04
 halfAL05
 halfMZ05
+halfAL06
+halfMZ06
 EOF
 
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@
 # then runs it to produce the JSON result files.
 #
 # Commandline arguments for this script, passed through by Vagrant.
-# 1st: Julia version:   0.3 | 0.4 | 0.5
+# 1st: Julia version:   0.4 | 0.5 | 0.6
 # 2nd: Test set to run: setup | all | AL | MZ
 #######################################################################
 

--- a/src/PackageEvaluator.jl
+++ b/src/PackageEvaluator.jl
@@ -1,0 +1,3 @@
+module PackageEvaluator
+# TODO make this a real package with an API
+end

--- a/website/README.md
+++ b/website/README.md
@@ -2,8 +2,8 @@
 
 Depending on the configuration it is run in, PkgEval will produce either
 
-* `0.3all.json`, `0.4all.json`, `0.5all.json`, or
-* `0.3AL.json`, `0.3MZ.json`, `0.4AL.json`, `0.4MZ.json`, `0.5AL.json`, `0.5MZ.json`
+* `0.4all.json`, `0.5all.json`, `0.6all.json`, or
+* `0.4AL.json`, `0.4MZ.json`, `0.5AL.json`, `0.5MZ.json`, `0.6AL.json`, `0.6MZ.json`
 
 The scripts in this folder take these results, enhance them, and construct
 the HTML and images for the website. If you have everything installed,

--- a/website/build.sh
+++ b/website/build.sh
@@ -23,7 +23,7 @@ IMGPATH=$HOME/github/pkg.julialang.org/img
 #scp nanosoldier1.csail.mit.edu:~/PkgEval/scripts/*.json ./
 cp $(dirname "$0")/../scripts/*.json .
 
-$JULIA --color=yes pull_repo_info.jl 0.3AL.json 0.3MZ.json 0.4AL.json 0.4MZ.json 0.5AL.json 0.5MZ.json
+$JULIA --color=yes pull_repo_info.jl 0.4AL.json 0.4MZ.json 0.5AL.json 0.5MZ.json 0.6AL.json 0.6MZ.json
 
 $JULIA --color=yes build_site_data.jl $LOGPATH $BADGEPATH $HISTPATH
 

--- a/website/build_index.jl
+++ b/website/build_index.jl
@@ -14,6 +14,7 @@
 print_with_color(:magenta, "Building index page and detail pages...\n")
 
 import JSON, Humanize, Mustache
+using Compat
 include("shared.jl")
 
 # Load test history
@@ -37,26 +38,26 @@ end
 pkg_names = sort(collect(keys(pkgs_by_name)))
 
 # Load logo
-jllogo_svg = readall("html/jllogo.svg")
+jllogo_svg = readstring("html/jllogo.svg")
 
 # Load stylesheet
-pkg_css = readall("html/pkg.css")
+pkg_css = readstring("html/pkg.css")
 
 # Load and render header
-index_head = Mustache.render(readall("html/indexhead.html"),
+index_head = Mustache.render(readstring("html/indexhead.html"),
     Dict("JLLOGO"      => jllogo_svg,
          "PKGCSS"      => pkg_css,
          "LASTUPDATED" => string(Dates.today()),  # YYYY-MM-DD
          "PKGCOUNT"    => string(length(pkg_names))) )
 
 # Load footer (no templates used)
-index_foot = readall("html/indexfoot.html")
+index_foot = readstring("html/indexfoot.html")
 
 # Load the template for a package
-index_pkg = readall("html/indexpkg.html")
+index_pkg = readstring("html/indexpkg.html")
 
 # Load the package detail template
-pkg_detail = readall("html/pkgdetail.html")
+pkg_detail = readstring("html/pkgdetail.html")
 
 # Helper function to produce history listings for each package
 function hist_table(hist_db, pkg_name, jl_ver)

--- a/website/build_pulse.jl
+++ b/website/build_pulse.jl
@@ -227,8 +227,8 @@ print_with_color(:magenta, "  Status changes...\n")
 
 MAX_DAYS_HIST = 3
 
-changes = Dict(RELEASE => Dict(), NIGHTLY => Dict())
-for JULIA_VERSION in [RELEASE, NIGHTLY]
+changes = Dict(LASTVER => Dict(), RELEASE => Dict(), NIGHTLY => Dict())
+for JULIA_VERSION in [LASTVER, RELEASE, NIGHTLY]
     for date in hist_dates[1:MAX_DAYS_HIST]
         changes[JULIA_VERSION][date] = []
     end
@@ -267,6 +267,9 @@ for JULIA_VERSION in [RELEASE, NIGHTLY]
     end
 end
 
+temp_data["LASTVERCHANGES"] = [Dict(
+    "TESTDATE"      => hist_dates[i],
+    "STATUSCHANGE"  => changes[LASTVER][hist_dates[i]]) for i in 1:MAX_DAYS_HIST]
 temp_data["RELEASECHANGES"] = [Dict(
     "TESTDATE"      => hist_dates[i],
     "STATUSCHANGE"  => changes[RELEASE][hist_dates[i]]) for i in 1:MAX_DAYS_HIST]

--- a/website/build_pulse.jl
+++ b/website/build_pulse.jl
@@ -12,13 +12,13 @@ print_with_color(:magenta, "Building pulse page...\n")
 import JSON, Mustache
 
 include("shared.jl")
-const RELEASE = "0.4"
-const NIGHTLY = "0.5"
-const LASTVER = "0.3"
-const CURVER  = "0.4"
-const NEXTVER = "0.5"
+const RELEASE = "0.5"
+const NIGHTLY = "0.6"
+const LASTVER = "0.4"
+const CURVER  = "0.5"
+const NEXTVER = "0.6"
 const JULIA_VERSIONS = [LASTVER,CURVER,NEXTVER]
-const VERSION_FOR_CHANGES = NEXTVER
+const VERSION_FOR_CHANGES = CURVER
 
 # Load test history
 date_str     = ARGS[1]

--- a/website/build_pulse.jl
+++ b/website/build_pulse.jl
@@ -10,6 +10,7 @@
 print_with_color(:magenta, "Building pulse page...\n")
 
 import JSON, Mustache
+using Compat
 
 include("shared.jl")
 const RELEASE = "0.5"
@@ -28,7 +29,7 @@ output_path  = ARGS[4]
 
 # Load package listing, turn into a more useful dictionary
 pkgs = JSON.parsefile("final.json")
-pkgdict = Dict([ver => Dict() for ver in JULIA_VERSIONS])
+pkgdict = Dict([(ver, Dict()) for ver in JULIA_VERSIONS])
 for pkg in pkgs
     pkgdict[pkg["jlver"]][pkg["name"]] = pkg
 end
@@ -37,7 +38,7 @@ end
 hist_db, pkgnames, hist_dates = load_hist_db(hist_db_file)
 
 # Load template, initialize template dictionary
-template = readall("html/pulse_temp.html")
+template = readstring("html/pulse_temp.html")
 temp_data = Dict{Any,Any}("UPDATEDATE" => string(dbdate_to_date(date_str)))
 
 #-----------------------------------------------------------------------
@@ -173,7 +174,7 @@ end
 
 print_with_color(:magenta, "  Status totals...\n")
 
-totals = Dict([ver => Dict() for ver in JULIA_VERSIONS])
+totals = Dict([(ver, Dict()) for ver in JULIA_VERSIONS])
 for JULIA_VERSION in JULIA_VERSIONS
     for pkgname in pkgnames
         hist_key = (pkgname, JULIA_VERSION)

--- a/website/html/indexhead.html
+++ b/website/html/indexhead.html
@@ -35,8 +35,8 @@
           Packages tested on
           <a href="http://julialang.org/downloads/">Julia versions</a>:
           <br>
-          v0.3.12 (previous release) —
-          <strong>v0.4.6 (current release)</strong> —
-          v0.5-pre (unstable)
+          v0.4.7 (previous release) —
+          <strong>v0.5.0 (current release)</strong> —
+          v0.6-pre (unstable)
         </p>
     </div>

--- a/website/html/pulse_temp.html
+++ b/website/html/pulse_temp.html
@@ -196,7 +196,19 @@
       </table>
 
       <div class="row">
-      <div class="col-sm-6">
+      <div class="col-sm-4">
+        <h4 style="text-align:center">Julia 0.4</h4>
+        {{#LASTVERCHANGES}}
+        <b>{{TESTDATE}}</b>
+        <ul>
+          {{#STATUSCHANGE}}
+          <li><a href="{{url}}/issues">{{name}}</a>: {{prev}} → <a href="{{purl}}"><span class="{{cur}}"><b>{{cur}}</b></span></a>.</li>
+          {{/STATUSCHANGE}}
+        </ul>
+        {{/LASTVERCHANGES}}
+      </div>
+
+      <div class="col-sm-4">
         <h4 style="text-align:center">Julia 0.5</h4>
         {{#RELEASECHANGES}}
         <b>{{TESTDATE}}</b>
@@ -208,7 +220,7 @@
         {{/RELEASECHANGES}}
       </div>
 
-      <div class="col-sm-6">
+      <div class="col-sm-4">
         <h4 style="text-align:center">Julia 0.6</h4>
         {{#NIGHTLYCHANGES}}
         <b>{{TESTDATE}}</b>

--- a/website/html/pulse_temp.html
+++ b/website/html/pulse_temp.html
@@ -138,25 +138,25 @@
       <h3 style="text-align:center">Testing status changes</h3>
       <div class="row">
       <div class="col-sm-4">
-        <img src="../img/0.3_false.svg"  class="img-responsive center-block" alt="Julia 0.3 Package Test Status">
-      </div>
-      <div class="col-sm-4">
         <img src="../img/0.4_false.svg"  class="img-responsive center-block" alt="Julia 0.4 Package Test Status">
       </div>
       <div class="col-sm-4">
         <img src="../img/0.5_false.svg"  class="img-responsive center-block" alt="Julia 0.5 Package Test Status">
       </div>
+      <div class="col-sm-4">
+        <img src="../img/0.6_false.svg"  class="img-responsive center-block" alt="Julia 0.6 Package Test Status">
+      </div>
       </div>
 
       <div class="row">
-      <div class="col-sm-4">
-        <img src="../img/0.3_true.svg"  class="img-responsive center-block" alt="Julia 0.3 Package Test Status">
-      </div>
       <div class="col-sm-4">
         <img src="../img/0.4_true.svg"  class="img-responsive center-block" alt="Julia 0.4 Package Test Status">
       </div>
       <div class="col-sm-4">
         <img src="../img/0.5_true.svg"  class="img-responsive center-block" alt="Julia 0.5 Package Test Status">
+      </div>
+      <div class="col-sm-4">
+        <img src="../img/0.6_true.svg"  class="img-responsive center-block" alt="Julia 0.6 Package Test Status">
       </div>
       </div>
 
@@ -170,7 +170,7 @@
           <td width="17%" style="color: grey;">Total</td>
         </tr>
         <tr>
-          <td style="border-right: 1px solid">Julia 0.3</td>
+          <td style="border-right: 1px solid">Julia 0.4</td>
           <td>{{LASTVERPASS}}</td>
           <td>{{LASTVERFAIL}}</td>
           <td>{{LASTVERNOTEST}}</td>
@@ -178,7 +178,7 @@
           <td>{{LASTVERTOTAL}}</td>
         </tr>
         <tr>
-          <td style="border-right: 1px solid">Julia 0.4</td>
+          <td style="border-right: 1px solid">Julia 0.5</td>
           <td>{{CURVERPASS}}</td>
           <td>{{CURVERFAIL}}</td>
           <td>{{CURVERNOTEST}}</td>
@@ -186,7 +186,7 @@
           <td>{{CURVERTOTAL}}</td>
         </tr>
         <tr>
-          <td style="border-right: 1px solid">Julia 0.5</td>
+          <td style="border-right: 1px solid">Julia 0.6</td>
           <td>{{NEXTVERPASS}}</td>
           <td>{{NEXTVERFAIL}}</td>
           <td>{{NEXTVERNOTEST}}</td>
@@ -197,7 +197,7 @@
 
       <div class="row">
       <div class="col-sm-6">
-        <h4 style="text-align:center">Julia 0.4</h4>
+        <h4 style="text-align:center">Julia 0.5</h4>
         {{#RELEASECHANGES}}
         <b>{{TESTDATE}}</b>
         <ul>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="col-sm-6">
-        <h4 style="text-align:center">Julia 0.5</h4>
+        <h4 style="text-align:center">Julia 0.6</h4>
         {{#NIGHTLYCHANGES}}
         <b>{{TESTDATE}}</b>
         <ul>

--- a/website/pulse_plots.jl
+++ b/website/pulse_plots.jl
@@ -28,7 +28,7 @@ print_with_color(:magenta, "  Totals and sanity checks...\n")
 # Collect totals for each Julia version by date and status
 totals = Dict()
 for ver in ["0.2","0.3","0.4","0.5","0.6"]
-    totals[ver] = Dict([date => Dict([status => 0 for status in keys(HUMANSTATUS)])
+    totals[ver] = Dict([(date, Dict([(status, 0) for status in keys(HUMANSTATUS)]))
                         for date in dates])
     for pkg in pkgnames
         key = (pkg, ver)
@@ -57,8 +57,8 @@ end
 print_with_color(:magenta, "  Printing main plot...\n")
 
 # Build an x-axis and y-axis for each version
-x_dates  = Dict([ver=>Date[] for ver in keys(totals)])
-y_totals = Dict([ver=>Int[]  for ver in keys(totals)])
+x_dates  = Dict([(ver,Date[]) for ver in keys(totals)])
+y_totals = Dict([(ver,Int[])  for ver in keys(totals)])
 for ver in keys(totals), date in dates
     y = totals[ver][date]["total"]
     y <= 0 && continue

--- a/website/pulse_plots.jl
+++ b/website/pulse_plots.jl
@@ -27,7 +27,7 @@ print_with_color(:magenta, "  Totals and sanity checks...\n")
 
 # Collect totals for each Julia version by date and status
 totals = Dict()
-for ver in ["0.2","0.3","0.4","0.5"]
+for ver in ["0.2","0.3","0.4","0.5","0.6"]
     totals[ver] = Dict([date => Dict([status => 0 for status in keys(HUMANSTATUS)])
                         for date in dates])
     for pkg in pkgnames
@@ -85,12 +85,15 @@ jl_date_vers = [Date(2014,08,20)  "v0.3.0"  250  true;
                 Date(2016,01,12)  "v0.4.3"  450  false;
                 Date(2016,03,17)  "v0.4.5"  400  false;
                 Date(2016,06,19)  "v0.4.6"  450  false;
+                Date(2016,09,18)  "v0.4.7"  400  false;
+                Date(2016,09,19)  "v0.5.0"  250  true;
 ]
 fig = figure(figsize=(10,4))  # inches
 plot(x_dates["0.2"], y_totals["0.2"], "r-",
      x_dates["0.3"], y_totals["0.3"], "g-",
      x_dates["0.4"], y_totals["0.4"], "b-",
      x_dates["0.5"], y_totals["0.5"], "k-",
+     x_dates["0.6"], y_totals["0.6"], "r-",
      linewidth=2)
 for i in 1:size(jl_date_vers,1)
     annotate(xy=(jl_date_vers[i,1],jl_date_vers[i,3]), s=jl_date_vers[i,2],
@@ -100,7 +103,7 @@ for i in 1:size(jl_date_vers,1)
 end
 xticks(rotation="vertical")
 ylabel("Number of Tagged Packages")
-legend(["0.2","0.3","0.4","0.5"], loc=2, fontsize="small")
+legend(["0.2","0.3","0.4","0.5","0.6"], loc=2, fontsize="small")
 open(joinpath(output_path,"allver.svg"), "w") do fp
     writemime(fp, "image/svg+xml", fig)
 end
@@ -154,6 +157,7 @@ const NEWCODES = ["tests_pass","tests_fail",
 # Build an x-axis and y-axis for each version
 jlv3 = Date(2014,08,20)
 jlv4 = Date(2015,10,08)
+jlv5 = Date(2016,09,19)
 
 for ver in keys(totals), aspercent in [true,false]
     x_dates_old  = Date[]
@@ -206,6 +210,11 @@ for ver in keys(totals), aspercent in [true,false]
         annotate(xy=(jlv4,aspercent?35:550), s="v0.4",
                  size="small", ha="left", backgroundcolor="w")
         axvline(x=jlv4, alpha=1.0, color="#333333")
+    end
+    if ver == "0.3" || ver == "0.4" || ver == "0.5"
+        annotate(xy=(jlv5,aspercent?35:550), s="v0.5",
+                 size="small", ha="left", backgroundcolor="w")
+        axvline(x=jlv5, alpha=1.0, color="#333333")
     end
     xticks(rotation="vertical")
     ylabel(string(aspercent?"Percentage":"Number", " of Packages"))


### PR DESCRIPTION
will revert https://github.com/JuliaCI/PackageEvaluator.jl/commit/f65c6c9193f60514febdbd17f66904c4ce84eec1, that's just for testing purpose to avoid breaking the live website if this goes horribly wrong

I'm going to want to change the pulse a little to show test status changes on all of 0.4, 0.5, and 0.6-dev. I've been manually checking 0.3 changes from the diff which is getting old.