### PR TITLE
Define ENV["JULIA_PKGEVAL"] when running in PackageEvaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Possible reasons include:
 * **Your package's tests or installation take too long**. There is a time limit of 30 minutes for installation, and a seperate 10 minute time limit for testing. You can either reduce your testing time, or exclude your package from testing.
 * **Your package requires too much memory**. The VMs only have 2 GB of RAM. You can either reduce your test memory usage, or exclude your package from testing.
 * **Your tests aren't being found / wrong test file is being run**. Your package needs a `test/runtests.jl` file. PackageEvaluator will execute it with `Pkg.test`.
+* **You don't want to run some of your tests on PackageEvaluator**. Wrap those tests inside `if get(ENV, "JULIA_PKGEVAL", "false") !== "true"; protected_tests; end`.
 * **Something else**. You'll probably need to check manually on the testing VM. See next section.
 
 (**Licenses** are searched for in the files listed in [`src/constants.jl`](https://github.com/IainNZ/PackageEvaluator.jl/blob/master/src/constants.jl). The goal is to support a variety of licenses. If your license isn't detected, please file a pull request with detection logic.)

--- a/src/preptest.jl
+++ b/src/preptest.jl
@@ -37,7 +37,7 @@ function prepare_test()
         print(fp, "xvfb-run ")
     end
     print(fp, "$TIMEOUTPATH 1200s ")
-    print(fp, "julia -e 'versioninfo(true); Pkg.test(\"", pkg_name, "\")'")
+    print(fp, "JULIA_PKGEVAL=true julia -e 'versioninfo(true); Pkg.test(\"", pkg_name, "\")'")
     print(fp, " 2>&1 | tee PKGEVAL_", pkg_name, "_test.log")
     close(fp)
 end


### PR DESCRIPTION
I have some "benchmark" tests in ImageCore.jl, but they're a little flaky on Travis and, presumably, PackageEvaluator. I'd rather not make pass/fail decisions based on the outcome of the benchmarks, so it seems reasonable to be able to determine whether the tests are running on PackageEvaluator. I'm not sure I really understand the architecture of this "package," but I'm attempting to ensure that an environment variable gets defined whenever a package is being tested.
