### PR TITLE
Remove unneeded css attribute

### DIFF
--- a/website/html/pkg.css
+++ b/website/html/pkg.css
@@ -15,7 +15,6 @@
       a {
         color: #428bca;
         text-decoration: none;
-        cursor: auto;
       }
       h1, h2, h3, h4, h5, h6 {
         font-family: inherit;


### PR DESCRIPTION
`cursor: auto` for `a` tag causes some web browsers (firefox 50) to not display
hand pointer icon for link