### PR TITLE
add hdfs, yarn and hive

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,6 +107,14 @@ sudo ./$AFSCRIPT --exclude-subdir --prefix=/usr/local
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 rm $AFSCRIPT
 
+#######################################################################
+# Setup environment for HDFS, Yarn and Hive
+HADOOPSCRIPTDIR="/home/vagrant/hadoop"
+git clone -b 'v0.0.1' --single-branch https://github.com/JuliaCI/PkgEvalHadoopEnv.git $HADOOPSCRIPTDIR
+echo $'\nJAVA_HOME=/usr/lib/jvm/java-7-oracle' >> /home/vagrant/.ssh/environment
+echo $'\nPermitUserEnvironment yes' | sudo tee --append /etc/ssh/sshd_config
+$HADOOPSCRIPTDIR/hadoop/setup_hdfs.sh
+$HADOOPSCRIPTDIR/hive/setup_hive.sh
 
 #######################################################################
 # Get PackageEvaluator scripts


### PR DESCRIPTION
This updates the package evaluator environment to include HDFS, Yarn and Hive services.
Enables running test scripts for packages Elly.jl and Hive.jl (or similar).

Ref.: https://github.com/JuliaLang/METADATA.jl/pull/6378#issuecomment-247754881

There is a separate repo [PkgEvalHadoopEnv](https://github.com/tanmaykm/PkgEvalHadoopEnv.git) with scripts that set up the environment (originally from Elly.jl and Hive.jl). If this is acceptable, I can transfer PkgEvalHadoopEnv to JuliaCI and use it for travis CI of the packages as well.

I have tested locally, restricting to only Elly.jl and Hive.jl. I didn't see a significant difference in memory consumption.