### PR TITLE
Revert "add hdfs, yarn and hive"

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,14 +107,6 @@ sudo ./$AFSCRIPT --exclude-subdir --prefix=/usr/local
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 rm $AFSCRIPT
 
-#######################################################################
-# Setup environment for HDFS, Yarn and Hive
-HADOOPSCRIPTDIR="/home/vagrant/hadoop"
-git clone -b 'v0.0.1' --single-branch https://github.com/JuliaCI/PkgEvalHadoopEnv.git $HADOOPSCRIPTDIR
-echo $'\nJAVA_HOME=/usr/lib/jvm/java-7-oracle' >> /home/vagrant/.ssh/environment
-echo $'\nPermitUserEnvironment yes' | sudo tee --append /etc/ssh/sshd_config
-$HADOOPSCRIPTDIR/hadoop/setup_hdfs.sh
-$HADOOPSCRIPTDIR/hive/setup_hive.sh
 
 #######################################################################
 # Get PackageEvaluator scripts


### PR DESCRIPTION
Reverts JuliaCI/PackageEvaluator.jl#145 since several packages have started failing with `OutOfMemoryError`, and https://github.com/JuliaCI/PackageEvaluator.jl/commit/66acd180f384c74d21dc3d97140af3614bbd40e6 wasn't quite enough to fix all of them.