### PR TITLE
Re-enable tests for Expect/Polyglot (fixes #90)

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -60,7 +60,8 @@ const LICFILES=["LICENSE", "LICENSE.md", "License.md", "LICENSE.txt", "LICENSE.r
 # PYTHON = requires a Python package that we haven't got installed
 # BREAKS = something about the package doesn't play nice
 # OPENGL = Needs OpenGL support, which XVFB can't handle
-const PKGOPTS = Dict([
+const PKGOPTS = Dict(vcat([
+    # Packages that break in all versions of Julia
     ("ActiveAppearanceModels" , :XVFB),      # GUI via Tk.jl
     ("AppleAccelerate"        , :OSX),
     ("Arduino"                , :BINARY),    # Needs libarduino
@@ -91,7 +92,6 @@ const PKGOPTS = Dict([
     ("EEG"                    , :XVFB),      # GUI via Tk.jl
     ("ElasticFDA"             , :XVFB),      # GUI via Tk.jl
     ("Elemental"              , :BINARY),    # Depends on MPI.jl
-    ("Expect"                 , :BREAKS),    # causes hangs on julia 0.3
     ("GLAbstraction"          , :OPENGL),
     ("GLFW"                   , :OPENGL),
     ("GLPlot"                 , :OPENGL),
@@ -135,7 +135,6 @@ const PKGOPTS = Dict([
     ("Pandas"                 , :PYTHON),    # Needs pandas
     ("Pardiso"                , :BINARY),    # Commercial software
     ("Plots"                  , :BINARY),    # Too many plotting package dependecies https://github.com/tbreloff/Plots.jl/issues/243
-    ("Polyglot"               , :BINARY),    # Froze PkgEval https://github.com/wavexx/Polyglot.jl/issues/1
     ("ProfileView"            , :XVFB),
     ("PyLexYacc"              , :PYTHON),    # Needs PLY and attrdict
     ("PyPlot"                 , :XVFB),      # GUI
@@ -160,4 +159,9 @@ const PKGOPTS = Dict([
     ("Winston"                , :XVFB),      # GUI via Tk.jl
     ("VML"                    , :BINARY),    # Needs MKL
     ("YT"                     , :PYTHON),    # Needs yt
-])
+],
+VERSION >= v"0.5"? []: [
+    # Packages that break in Julia<0.5
+    ("Expect"                 , :BREAKS),    # Freezes PkgEval
+    ("Polyglot"               , :BREAKS),    # Freezes PkgEval
+]))


### PR DESCRIPTION
- Expect 0.2.0 should fix stalls on Julia 0.5 and above
- Also re-enable Polyglot (which broke due to Expect)