### PR TITLE
Use timeout+unshare on linux

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -94,7 +94,6 @@ const PKGOPTS = Dict([
     ("EEG"                    , :XVFB),      # GUI via Tk.jl
     ("ElasticFDA"             , :XVFB),      # GUI via Tk.jl
     ("Elemental"              , :BINARY),    # Depends on MPI.jl
-    ("Expect"                 , :BREAKS),    # causes hangs on julia 0.3
     ("GLAbstraction"          , :OPENGL),
     ("GLFW"                   , :OPENGL),
     ("GLPlot"                 , :OPENGL),
@@ -138,7 +137,6 @@ const PKGOPTS = Dict([
     ("Pandas"                 , :PYTHON),    # Needs pandas
     ("Pardiso"                , :BINARY),    # Commercial software
     ("Plots"                  , :BINARY),    # Too many plotting package dependecies https://github.com/tbreloff/Plots.jl/issues/243
-    ("Polyglot"               , :BINARY),    # Froze PkgEval https://github.com/wavexx/Polyglot.jl/issues/1
     ("ProfileView"            , :XVFB),
     ("PyLexYacc"              , :PYTHON),    # Needs PLY and attrdict
     ("PyPlot"                 , :XVFB),      # GUI

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -53,6 +53,9 @@ const LICFILES=["LICENSE", "LICENSE.md", "License.md", "LICENSE.txt", "LICENSE.r
                  "README",  "README.md",                "README.txt",
                 "COPYING", "COPYING.md",               "COPYING.txt"]
 
+# Package testing defaults
+const TEST_TIMEOUT = 1200
+
 # Special package treatments
 # XVFB   = requires X virtual framebuffer
 # BINARY = can't run due to a binary dependency that can't be satisfied

--- a/src/preptest.jl
+++ b/src/preptest.jl
@@ -7,6 +7,7 @@
 # See description in scripts/setup.sh for the purpose of this file
 #######################################################################
 
+using Compat
 include("constants.jl")
 
 function prepare_test()

--- a/src/preptest.jl
+++ b/src/preptest.jl
@@ -7,7 +7,6 @@
 # See description in scripts/setup.sh for the purpose of this file
 #######################################################################
 
-using Compat
 include("constants.jl")
 
 function prepare_test()
@@ -34,16 +33,9 @@ function prepare_test()
     fp = open(string(pkg_name,".sh"),"w")
     println(fp, "set -o pipefail")  # So tee doesn't swallow the exit code
 
-    if is_apple()
-        # Force usage of coreutils' timeout
-        print(fp, "gtimeout -s9 $(TEST_TIMEOUT)s ")
-    elseif is_linux()
-        # Separate PID namespace to prevent any child process to escape
-        # the timeout invocation and lock our tests
-        print(fp, "sudo -E timeout -s9 $(TEST_TIMEOUT)s unshare -fp runuser -u \$USER -- ")
-    else
-        print(fp, "timeout -s9 $(TEST_TIMEOUT)s ")
-    end
+    # Separate PID namespace to prevent any child process to escape
+    # the timeout invocation and lock our tests
+    print(fp, "sudo -E timeout -s9 $(TEST_TIMEOUT)s unshare -fp runuser -u \$USER -- ")
 
     if get(PKGOPTS, pkg_name, :NORMAL) == :XVFB
         print(fp, "xvfb-run ")

--- a/src/preptest.jl
+++ b/src/preptest.jl
@@ -8,9 +8,6 @@
 #######################################################################
 
 include("constants.jl")
-# TODO: uncomment this (and deal with deprecation) if pkgeval gets generalized to run on mac
-#const TIMEOUTPATH = @osx? "gtimeout" : "timeout"
-const TIMEOUTPATH = "timeout"
 
 function prepare_test()
     pkg_name = ARGS[1]
@@ -35,10 +32,21 @@ function prepare_test()
     # Tests exist, so lets create a shell script to run them
     fp = open(string(pkg_name,".sh"),"w")
     println(fp, "set -o pipefail")  # So tee doesn't swallow the exit code
+
+    if is_apple()
+        # Force usage of coreutils' timeout
+        print(fp, "gtimeout -s9 $(TEST_TIMEOUT)s ")
+    elseif is_linux()
+        # Separate PID namespace to prevent any child process to escape
+        # the timeout invocation and lock our tests
+        print(fp, "sudo -E timeout -s9 $(TEST_TIMEOUT)s unshare -fp runuser -u \$USER -- ")
+    else
+        print(fp, "timeout -s9 $(TEST_TIMEOUT)s ")
+    end
+
     if get(PKGOPTS, pkg_name, :NORMAL) == :XVFB
         print(fp, "xvfb-run ")
     end
-    print(fp, "$TIMEOUTPATH -s 9 1200s ")
     print(fp, "julia -e 'versioninfo(true); Pkg.test(\"", pkg_name, "\")'")
     print(fp, " 2>&1 | tee PKGEVAL_", pkg_name, "_test.log")
     close(fp)


### PR DESCRIPTION
This is another take at re-enabling testing on Expect+Polyglot the-right-way™.
See https://github.com/JuliaCI/PackageEvaluator.jl/pull/158#issuecomment-293716777

In short: test freeze because some children of the julia process are not killed by timeout, keeping tee alive indefinitely. Instead of skipping the tests or killing tee, we ensure any process spawned by julia cannot escape SIGKILL.

I also moved the xvfb invocation *in* the timeout as well. Since we need to know the current running platform, I removed the TIMEOUTPATH and instead added a global constant for the actual timeout value, which seems more appropriate.

I tested this on a fresh trusty VM and on debian sid, but I cannot run the entire vagrant machinery from scratch here (slow network connection). I apologize if something is missing.