### PR TITLE
Add optional comma to MPL license regex

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -18,8 +18,8 @@ const LICENSES=[("MIT",[
                     r"mit \"expat\" license",
                     r"permission is hereby granted, free of charge,"]),
                 ("MPL v2",[
-                    r"mpl version 2",
-                    r"mozilla public license version 2"]),
+                    r"mpl,? version 2",
+                    r"mozilla public license,? version 2"]),
                 ("GPL v2",[
                     r"gpl version 2",
                     r"gpl ?v2",


### PR DESCRIPTION
Now matches, for example, https://github.com/invenia/Dispatcher.jl