### PR TITLE
LibHealpix.jl needs libtool to compile a dependency

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,6 +81,8 @@ sudo apt-get install gfortran pkg-config
 sudo apt-get install unzip
 # Need cmake for e.g. GLFW.jl, Metis.jl
 sudo apt-get install cmake
+# Need libtool for LibHealpix.jl
+sudo apt-get install libtool
 # Install R for e.g. Rif.jl, RCall.jl
 sudo apt-get install r-base r-base-dev
 # Install gmsh and libav-tools for EllipticFEM.jl


### PR DESCRIPTION
I am pretty embarrassed by the number of red status symbols next to my package so I'm trying to fix that. Without libtool installed, PkgEval fails to build a dependency with the following error.

```
Makefile.am:3: error: Libtool library used but 'LIBTOOL' is undefined
Makefile.am:3:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
Makefile.am:3:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
Makefile.am:3:   If 'LT_INIT' is in 'configure.ac', make sure
Makefile.am:3:   its definition is in aclocal's search path.
```

This PR isn't quite enough on its own to make LibHealpix.jl pass on PkgEval, but I think the next tag should pass... Hopefully :)