### PR TITLE
Fixes to work on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ GitHub
 JLD
 PyPlot
 Compat
+TimeZones

--- a/website/build_index.jl
+++ b/website/build_index.jl
@@ -13,8 +13,7 @@
 
 print_with_color(:magenta, "Building index page and detail pages...\n")
 
-import JSON, Humanize, Mustache
-using Compat
+using Compat, JSON, Humanize, Mustache, TimeZones
 include("shared.jl")
 
 # Load test history
@@ -96,11 +95,10 @@ function hist_table(hist_db, pkg_name, jl_ver)
     return join(reverse(output_strs))
 end
 
+parsedate(s::AbstractString) =
+    TimeZones.utc(parse(ZonedDateTime, s, dateformat"yyyy-mm-dd HH:MM:SS zzzzz"))
 
-
-
-
-listings = UTF8String[]
+listings = String[]
 
 # For each package in the data set
 for pkg_name in pkg_names
@@ -139,8 +137,7 @@ for pkg_name in pkg_names
             "STATUS"        => pkg["status"],
             "SHA"           => pkg["gitsha"],
             "VER"           => pkg["version"],
-            "DTSTR"         => Humanize.timedelta(Dates.now() -
-                                    DateTime(pkg["gitdate"],"y-m-d H:M:S")),
+            "DTSTR"         => Humanize.timedelta(Dates.now() - parsedate(pkg["gitdate"])),
             "HUMAN_STATUS"  => HUMANSTATUS[pkg["status"]],
             # For per-package detail page
             "SVG_URL"      => string("../badges/",

--- a/website/pulse_plots.jl
+++ b/website/pulse_plots.jl
@@ -132,7 +132,7 @@ xticks(rotation="vertical")
 ylabel("Number of Tagged Packages")
 legend(["0.2","0.3","0.4","0.5","0.6"], loc=2, fontsize="small")
 open(joinpath(output_path,"allver.svg"), "w") do fp
-    writemime(fp, "image/svg+xml", fig)
+    show(fp, "image/svg+xml", fig)
 end
 
 
@@ -142,7 +142,7 @@ end
 print_with_color(:magenta, "  Printing star plot...\n")
 
 star_hist, star_dates = load_star_db(star_db_file)
-star_totals = [d => 0 for d in dates_all]
+star_totals = Dict(d => 0 for d in dates_all)
 for pkg in keys(star_hist)
     for (date,stars) in star_hist[pkg]
         star_totals[date] += stars
@@ -167,7 +167,7 @@ plot(x_dates, y_totals,
 xticks(rotation="vertical")
 ylabel("Number of stars")
 open(joinpath(output_path,"stars.svg"), "w") do fp
-    writemime(fp, "image/svg+xml", fig)
+    show(fp, "image/svg+xml", fig)
 end
 
 
@@ -189,9 +189,9 @@ jlv6 = Date(2017,06,19)
 
 for ver in keys(totals), aspercent in [true,false]
     x_dates_old  = Date[]
-    y_totals_old = [key=>Any[] for key in OLDCODES]
+    y_totals_old = Dict(key=>Any[] for key in OLDCODES)
     x_dates      = Date[]
-    y_totals     = [key=>Any[] for key in NEWCODES]
+    y_totals     = Dict(key=>Any[] for key in NEWCODES)
     for i in 1:length(dates)
         v = totals[ver][dates[i]]
         d = dbdate_to_date(dates[i])
@@ -254,6 +254,6 @@ for ver in keys(totals), aspercent in [true,false]
     ylim(ymin = 0, ymax = aspercent ? 80 : 1000 )
     title(string("Julia v$(ver)", aspercent ? " (relative)" : ""))
     open(joinpath(output_path,"$(ver)_$(aspercent).svg"), "w") do fp
-        writemime(fp, "image/svg+xml", fig)
+        show(fp, "image/svg+xml", fig)
     end
 end

--- a/website/shared.jl
+++ b/website/shared.jl
@@ -41,7 +41,7 @@ dbdate_to_date(dbdate) =
 function load_hist_db(hist_db_file)
     all_hist = readcsv(hist_db_file, AbstractString)
     # Remove all the whitespace from all fields
-    map!(strip, all_hist)
+    map!(strip, all_hist, all_hist)
     # Form the dictionaries and sets
     hist_db  = Dict()
     pkg_set  = Set()
@@ -79,7 +79,7 @@ function load_star_db(hist_file)
     # Load CSV
     all_hist = readcsv(hist_file, AbstractString)
     # Remove all the whitespace
-    map!(strip, all_hist)
+    map!(strip, all_hist, all_hist)
     # Store results in a dictionary keyed on on package
     # names, with values being an array of (date,stars)
     hist = Dict()


### PR DESCRIPTION
Some of the code here relied on early Julia behavior which has since been changed/removed, which was causing errors.

I've also added a dependency on the TimeZones package for proper parsing of dates with time zones after a discussion with @omus. Its use is limited to one instance where we parse the raw date with a time zone then convert to UTC as a `DateTime`. Proper handling of this case is not available in the Dates module.

Using this branch, I was able to successfully update the website.