### PR TITLE
Enable cx16 on VBox

### DIFF
--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -7,6 +7,12 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 3072
     v.cpus = 2
+    v.customize [
+      "setextradata",
+      :id,
+      "VBoxInternal/CPUM/CMPXCHG16B",
+      "1"
+    ]
   end
 
   #---------------------------------------------------------------------


### PR DESCRIPTION
The `JULIA_CPU_TARGET=generic` requires the cpu feature `cx16` [1].
Virtualbox has a bug where that is disables [2].

Ergo enable it in the Vagrantfile to avoid issues.

[1] https://github.com/JuliaLang/julia/blob/c8d52d210154584974607313d23455c0bbde050b/src/processor_x86.cpp#L151
[2] https://www.virtualbox.org/ticket/10792