### PR TITLE
A couple of fixes for 0.7

### DIFF
--- a/src/prepjson.jl
+++ b/src/prepjson.jl
@@ -8,7 +8,9 @@
 # exist, as well as other useful information about the package.
 #######################################################################
 
-import JSON
+using JSON
+using Compat
+using Compat.Unicode
 
 include("constants.jl")
 

--- a/src/preptest.jl
+++ b/src/preptest.jl
@@ -39,7 +39,9 @@ function prepare_test()
         print(fp, "xvfb-run ")
     end
     print(fp, "$TIMEOUTPATH -s 9 900s ")
-    print(fp, "julia -e 'versioninfo(true); Pkg.test(\"", pkg_name, "\")'")
+    # Avoid emitting a deprecation warning for every package tested on 0.7
+    print(fp, "julia -e 'VERSION >= v\"0.7.0-DEV.467\" ? versioninfo(verbose=true) :")
+    print(fp, " versioninfo(true); Pkg.test(\"", pkg_name, "\")'")
     print(fp, " 2>&1 | tee PKGEVAL_", pkg_name, "_test.log")
     close(fp)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 JSON
+Compat 0.41.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+using Compat
+using Compat.Test
+
 # Check src/constants.jl loads
 src_dir = joinpath(splitdir(@__FILE__)[1], "..", "src")
 include(joinpath(src_dir, "constants.jl"))
@@ -7,10 +10,10 @@ try
     run(`$(ENV["_"]) $(joinpath(src_dir, "preptest.jl")) Arduino`)
     error("preptest didn't exit correctly")
 catch err
-    @assert contains(err.msg, "255")
+    @test contains(err.msg, "255")
 end
 run(`$(ENV["_"]) $(joinpath(src_dir, "preptest.jl")) JSON`)
-@assert isfile("JSON.sh")
+@test isfile("JSON.sh")
 rm(joinpath(pwd(),"JSON.sh"))
 
 # Check prepjson works
@@ -19,10 +22,10 @@ open("PKGEVAL_JSON_test.log","w") do nothing end
 run(`$(ENV["_"]) $(joinpath(src_dir, "prepjson.jl")) JSON 0 $(pwd())`)
 rm("PKGEVAL_JSON_add.log")
 rm("PKGEVAL_JSON_test.log")
-@assert isfile("JSON.json")
+@test isfile("JSON.json")
 
 # Check joinjson works
 run(`$(ENV["_"]) $(joinpath(src_dir, "joinjson.jl")) $(pwd()) test`)
-@assert isfile("test.json")
+@test isfile("test.json")
 rm("JSON.json")
 rm("test.json")

--- a/website/build_index.jl
+++ b/website/build_index.jl
@@ -43,7 +43,7 @@ jllogo_svg = read("html/jllogo.svg", String)
 pkg_css = read("html/pkg.css", String)
 
 # Load and render header
-index_head = Mustache.render(readstring("html/indexhead.html"),
+index_head = Mustache.render(read("html/indexhead.html", String),
     Dict("JLLOGO"      => jllogo_svg,
          "PKGCSS"      => pkg_css,
          "LASTUPDATED" => string(Dates.today()),  # YYYY-MM-DD

--- a/website/build_pulse.jl
+++ b/website/build_pulse.jl
@@ -11,6 +11,7 @@ print_with_color(:magenta, "Building pulse page...\n")
 
 import JSON, Mustache
 using Compat
+using Compat.Printf
 
 include("shared.jl")
 const RELEASE = "0.6"
@@ -38,7 +39,7 @@ end
 hist_db, pkgnames, hist_dates = load_hist_db(hist_db_file)
 
 # Load template, initialize template dictionary
-template = readstring("html/pulse_temp.html")
+template = read("html/pulse_temp.html", String)
 temp_data = Dict{Any,Any}("UPDATEDATE" => string(dbdate_to_date(date_str)))
 
 #-----------------------------------------------------------------------


### PR DESCRIPTION
This PR gets around a 0.7 failure for `lowercase` moving to the Unicode stdlib package, avoids a deprecation warning from `versioninfo` for every package tested on 0.7, and converts the tests here to use the testing framework rather than `@assert`s.