### PR TITLE
Drop 0.5, redistribute VMs across 0.6 and 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
     - linux
-    - osx
 julia:
     - 0.5
     - 0.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
     - linux
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Possible reasons include:
       dependencies that are used for a full PackageEvaluator run, but
       do not do any testing.
     * `all`: do `setup` and evaluate all the packages.
-    * `AK` or `LZ`: evaluate only packages with names beginning with those letters.
+    * `AF`, `GO`, `PZ`: evaluate only packages with names beginning with those letters.
 * Each combination of settings corresponds to a named virtual machine - see `scripts/Vagrantfile` for the list of the VMs.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PackageEvaluator
 
 The purpose of PackageEvaluator is to attempt to test every Julia package nightly, and to provide the information required to generate the [Julia package listing](http://pkg.julialang.org/).
 
-This is currently done for Julia 0.5, 0.6, and nightly, and the tests are run in Ubuntu 14.04 LTS ("Trusty Tahr") virtual machines managed with [Vagrant](https://www.vagrantup.com/). This allows users to debug why their tests are failing, and allows PackageEvaluator to be run almost anywhere.
+This is currently done for Julia 0.6 and nightly, and the tests are run in Ubuntu 14.04 LTS ("Trusty Tahr") virtual machines managed with [Vagrant](https://www.vagrantup.com/). This allows users to debug why their tests are failing, and allows PackageEvaluator to be run almost anywhere.
 
 The code itself, in particular `scripts/setup.sh`, is heavily commented, so check that out for more information.
 
@@ -34,7 +34,7 @@ Possible reasons include:
 * The configuration of the virtual machine, including the operating system to use, live in the [`Vagrantfile`](https://github.com/JuliaCI/PackageEvaluator.jl/blob/master/scripts/Vagrantfile).
 * When the virtual machine(s) are launched with `vagrant up`, a *provisioning script* called [`setup.sh`](https://github.com/JuliaCI/PackageEvaluator.jl/blob/master/scripts/setup.sh) is run.
 * This script takes two arguments. The first is the version of Julia
-  to use (`0.5` or `0.6` or `0.7`)
+  to use (`0.6` or `0.7`)
 * The second determines the mode to operate in:
     * `setup`: set up the machine with Julia and the same
       dependencies that are used for a full PackageEvaluator run, but

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 JSON
 Humanize
 Mustache

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,5 +7,5 @@ Requests
 GitHub
 JLD
 PyPlot
-Compat
+Compat 0.41.0
 TimeZones

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -17,14 +17,6 @@ Vagrant.configure("2") do |config|
 
   #---------------------------------------------------------------------
   # SETUP ONLY
-  config.vm.define :setup05 do |setup05|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.5", "setup"],
-      keep_color: true,
-      privileged: false
-  end
-
   config.vm.define :setup06 do |setup06|
     config.vm.provision :shell,
       path: "setup.sh",
@@ -43,14 +35,6 @@ Vagrant.configure("2") do |config|
 
   #---------------------------------------------------------------------
   # ALL PACKAGES
-  config.vm.define :all05 do |all05|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.5", "all"],
-      keep_color: true,
-      privileged: false
-  end
-
   config.vm.define :all06 do |all06|
     config.vm.provision :shell,
       path: "setup.sh",
@@ -69,21 +53,6 @@ Vagrant.configure("2") do |config|
 
   #---------------------------------------------------------------------
   # HALF PACKAGES
-  config.vm.define :halfAK05 do |halfAK05|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.5", "AK"],
-      keep_color: true,
-      privileged: false
-  end
-  config.vm.define :halfLZ05 do |halfLZ05|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.5", "LZ"],
-      keep_color: true,
-      privileged: false
-  end
-
   config.vm.define :halfAK06 do |halfAK06|
     config.vm.provision :shell,
       path: "setup.sh",

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -52,35 +52,52 @@ Vagrant.configure("2") do |config|
   end
 
   #---------------------------------------------------------------------
-  # HALF PACKAGES
-  config.vm.define :halfAK06 do |halfAK06|
+  # THIRD PACKAGES
+  config.vm.define :thirdAF06 do |thirdAF06|
     config.vm.provision :shell,
       path: "setup.sh",
-      args: ["0.6", "AK"],
-      keep_color: true,
-      privileged: false
-  end
-  config.vm.define :halfLZ06 do |halfLZ06|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.6", "LZ"],
+      args: ["0.6", "AF"],
       keep_color: true,
       privileged: false
   end
 
-  config.vm.define :halfAK07 do |halfAK07|
+  config.vm.define :thirdGO06 do |thirdGO06|
     config.vm.provision :shell,
       path: "setup.sh",
-      args: ["0.7", "AK"],
-      keep_color: true,
-      privileged: false
-  end
-  config.vm.define :halfLZ07 do |halfLZ07|
-    config.vm.provision :shell,
-      path: "setup.sh",
-      args: ["0.7", "LZ"],
+      args: ["0.6", "GO"],
       keep_color: true,
       privileged: false
   end
 
+  config.vm.define :thirdPZ06 do |thirdPZ06|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.6", "PZ"],
+      keep_color: true,
+      privileged: false
+  end
+
+  config.vm.define :thirdAF07 do |thirdAF07|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.7", "AF"],
+      keep_color: true,
+      privileged: false
+  end
+
+  config.vm.define :thirdGO07 do |thirdGO07|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.7", "GO"],
+      keep_color: true,
+      privileged: false
+  end
+
+  config.vm.define :thirdPZ07 do |thirdPZ07|
+    config.vm.provision :shell,
+      path: "setup.sh",
+      args: ["0.7", "PZ"],
+      keep_color: true,
+      privileged: false
+  end
 end

--- a/scripts/runvagrant.sh
+++ b/scripts/runvagrant.sh
@@ -9,7 +9,7 @@
 # work happens during provisioning. Afterwards, it tears them down.
 # Based off of
 #  http://server.dzone.com/articles/parallel-provisioning-speeding
-# Can either run three or six machines in parallel
+# Can either run two or six machines in parallel
 #######################################################################
 
 # Remove results from previous runs
@@ -23,7 +23,7 @@ parallel_provision() {
         sh -c 'vagrant provision BOXNAME >BOXNAME.out.txt 2>&1 || echo "Error Occurred: BOXNAME"'
 }
 
-if [ "$1" == "three" ]
+if [ "$1" == "two" ]
 then
     vagrant up --no-provision all06
     vagrant up --no-provision all07
@@ -35,17 +35,21 @@ all07
 EOF
 
 else
-    vagrant up --no-provision halfAK06
-    vagrant up --no-provision halfLZ06
-    vagrant up --no-provision halfAK07
-    vagrant up --no-provision halfLZ07
+    vagrant up --no-provision thirdAF06
+    vagrant up --no-provision thirdGO06
+    vagrant up --no-provision thirdPZ06
+    vagrant up --no-provision thirdAF07
+    vagrant up --no-provision thirdGO07
+    vagrant up --no-provision thirdPZ07
 
     # Provision in parallel
     cat <<EOF | parallel_provision
-halfAK06
-halfLZ06
-halfAK07
-halfLZ07
+thirdAF06
+thirdGO06
+thirdPZ06
+thirdAF07
+thirdGO07
+thirdPZ07
 EOF
 
 fi

--- a/scripts/runvagrant.sh
+++ b/scripts/runvagrant.sh
@@ -25,20 +25,16 @@ parallel_provision() {
 
 if [ "$1" == "three" ]
 then
-    vagrant up --no-provision all05
     vagrant up --no-provision all06
     vagrant up --no-provision all07
 
     # Provision in parallel
     cat <<EOF | parallel_provision
-all05
 all06
 all07
 EOF
 
 else
-    vagrant up --no-provision halfAK05
-    vagrant up --no-provision halfLZ05
     vagrant up --no-provision halfAK06
     vagrant up --no-provision halfLZ06
     vagrant up --no-provision halfAK07
@@ -46,8 +42,6 @@ else
 
     # Provision in parallel
     cat <<EOF | parallel_provision
-halfAK05
-halfLZ05
 halfAK06
 halfLZ06
 halfAK07

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,7 +11,7 @@
 #
 # Commandline arguments for this script, passed through by Vagrant.
 # 1st: Julia version:   0.6 | 0.7
-# 2nd: Test set to run: setup | all | AK | LZ
+# 2nd: Test set to run: setup | all | AF | GO | PZ
 #######################################################################
 
 
@@ -138,12 +138,15 @@ julia -e "Pkg.init(); println(Pkg.dir())"
 if [ "$2" == "all" ]
 then
     LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/*
-elif [ "$2" == "AK" ]
+elif [ "$2" == "AF" ]
 then
-    LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/[A-K,a-k]*;
-elif [ "$2" == "LZ" ]
+    LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/[A-F,a-f]*;
+elif [ "$2" == "GO" ]
 then
-    LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/[L-Z,l-z]*;
+    LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/[G-O,g-o]*;
+elif [ "$2" == "PZ" ]
+then
+    LOOPOVER=/home/vagrant/.julia/v${1}/METADATA/[P-Z,p-z]*;
 fi
 # For every package name...
 for f in $LOOPOVER;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@
 # then runs it to produce the JSON result files.
 #
 # Commandline arguments for this script, passed through by Vagrant.
-# 1st: Julia version:   0.5 | 0.6 | 0.7
+# 1st: Julia version:   0.6 | 0.7
 # 2nd: Test set to run: setup | all | AK | LZ
 #######################################################################
 

--- a/website/README.md
+++ b/website/README.md
@@ -2,8 +2,8 @@
 
 Depending on the configuration it is run in, PkgEval will produce either
 
-* `0.5all.json`, `0.6all.json`, `0.7all.json`, or
-* `0.5AK.json`, `0.5LZ.json`, `0.6AK.json`, `0.6LZ.json`, `0.7AK.json`, `0.7LZ.json`
+* `0.6all.json`, `0.7all.json`, or
+* `0.6AK.json`, `0.6LZ.json`, `0.7AK.json`, `0.7LZ.json`
 
 The scripts in this folder take these results, enhance them, and construct
 the HTML and images for the website. If you have everything installed,

--- a/website/README.md
+++ b/website/README.md
@@ -3,7 +3,7 @@
 Depending on the configuration it is run in, PkgEval will produce either
 
 * `0.6all.json`, `0.7all.json`, or
-* `0.6AK.json`, `0.6LZ.json`, `0.7AK.json`, `0.7LZ.json`
+* `0.6AF.json`, `0.6GO.json`, `0.6PZ.json`, `0.7AF.json`, `0.7GO.json`, `0.7PZ.json`
 
 The scripts in this folder take these results, enhance them, and construct
 the HTML and images for the website. If you have everything installed,

--- a/website/build.sh
+++ b/website/build.sh
@@ -26,7 +26,7 @@ gunzip -f -k $HISTPATH.gz
 #scp nanosoldier1.csail.mit.edu:~/PkgEval/scripts/*.json ./
 cp $(dirname "$0")/../scripts/*.json .
 
-$JULIA --color=yes pull_repo_info.jl 0.5AK.json 0.5LZ.json 0.6AK.json 0.6LZ.json 0.7AK.json 0.7LZ.json
+$JULIA --color=yes pull_repo_info.jl 0.6AK.json 0.6LZ.json 0.7AK.json 0.7LZ.json
 
 $JULIA --color=yes build_site_data.jl $LOGPATH $BADGEPATH $HISTPATH
 

--- a/website/build.sh
+++ b/website/build.sh
@@ -26,7 +26,7 @@ gunzip -f -k $HISTPATH.gz
 #scp nanosoldier1.csail.mit.edu:~/PkgEval/scripts/*.json ./
 cp $(dirname "$0")/../scripts/*.json .
 
-$JULIA --color=yes pull_repo_info.jl 0.6AK.json 0.6LZ.json 0.7AK.json 0.7LZ.json
+$JULIA --color=yes pull_repo_info.jl 0.6AF.json 0.6GO.json 0.6PZ.json 0.7AF.json 0.7GO.json 0.7PZ.json
 
 $JULIA --color=yes build_site_data.jl $LOGPATH $BADGEPATH $HISTPATH
 

--- a/website/html/indexhead.html
+++ b/website/html/indexhead.html
@@ -40,7 +40,7 @@
         Packages tested on
         <a href="http://julialang.org/downloads/">Julia versions</a>:
         <br/>
-        v0.5.2 (previous release) —
+        v0.5.2 (unmaintained release) —
         <strong>v0.6.2 (current release)</strong> —
         v0.7.0-DEV (unstable)
       </p>


### PR DESCRIPTION
0.5 is being declared as unmaintained. As such, its PackageEvaluator workers will be redistributed to 0.6 and 0.7. This PR tackles that (and a couple of extra things) in 4 distinct commits:

1. Raise the minimum required Compat version to 0.41.0. Not doing this earlier was an oversight.
2. Remove Travis testing on macOS. It just slows down development here, since PackageEvaluator is not run on macOS. Should we test on other platforms in the future, we can reenable it.
3. Stop running tests on 0.5. This commit removes 0.5 without redistributing the workers.
4. Redistribute the 0.5 workers such that 0.6 and 0.7 each receive three workers instead of two. (See individual commit message for more information.)