### PR TITLE
Fixes for the pulse page

### DIFF
--- a/website/html/pulse_temp.html
+++ b/website/html/pulse_temp.html
@@ -139,19 +139,19 @@
 
       <h3 id="testing-status-changes">Testing status changes</h3>
       <div class="row">
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <img src="../img/0.6_false.svg"  class="img-responsive center-block" alt="Julia 0.6 Package Test Status">
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <img src="../img/0.7_false.svg"  class="img-responsive center-block" alt="Julia 0.7 Package Test Status">
       </div>
       </div>
 
       <div class="row">
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <img src="../img/0.6_true.svg"  class="img-responsive center-block" alt="Julia 0.6 Package Test Status">
       </div>
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <img src="../img/0.7_true.svg"  class="img-responsive center-block" alt="Julia 0.7 Package Test Status">
       </div>
       </div>
@@ -184,7 +184,7 @@
       </table>
 
       <div class="row">
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <h4>Julia 0.6</h4>
         {{#RELEASECHANGES}}
         <b>{{TESTDATE}}</b>
@@ -196,7 +196,7 @@
         {{/RELEASECHANGES}}
       </div>
 
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <h4>Julia 0.7</h4>
         {{#NIGHTLYCHANGES}}
         <b>{{TESTDATE}}</b>

--- a/website/pulse_plots.jl
+++ b/website/pulse_plots.jl
@@ -46,7 +46,8 @@ blacklist_dates = [
     "20170712",
     "20170830",
     "20170924",
-    "20171001"
+    "20171001",
+    "20180108", # 0.7 was double counted
 ]
 dates = setdiff(dates_all, blacklist_dates)
 
@@ -73,8 +74,8 @@ end
 println("    ", dates[1], "  ", dates[2])
 for status in keys(HUMANSTATUS)
     @printf("    %20s   %4d   %4d\n", status,
-        totals["0.4"][dates[1]][status],
-        totals["0.4"][dates[2]][status])
+        totals["0.6"][dates[1]][status],
+        totals["0.6"][dates[2]][status])
 end
 
 #-----------------------------------------------------------------------


### PR DESCRIPTION
The first commit here redistributes the page space on the pulse page. The HTML for the pulse page used `<div class="col-sm-4">` for the columns of test results, which made sense when there were three Julia versions to show, since 12/3=4. However, now that we're only doing 0.6 and 0.7, a bunch of whitespace is left on the right. This divides the space evenly, putting both at `col-sm-6`.

Packages seem to have been double counted on 2018-01-08, so that date has been removed from the plots to avoid a bogus spike.

Lastly, the Julia version used for sanity check counts has been bumped to 0.6.